### PR TITLE
Add (optional, feature-gated) proptest::Arbitrary implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,9 @@ exclude = [".cargo/**/*", ".github/**/*"]
 all-features = true
 
 [dependencies]
+proptest = { version = "1.0.0", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 
 [features]
 serde1 = ["serde"]
+proptest1 = ["proptest"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,8 @@ use std::{
     sync::Arc,
 };
 
+#[cfg(feature = "proptest1")]
+mod proptest_impls;
 #[cfg(feature = "serde1")]
 mod serde_impls;
 #[cfg(test)]

--- a/src/proptest_impls.rs
+++ b/src/proptest_impls.rs
@@ -1,0 +1,28 @@
+// Copyright (c) The camino Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! [proptest::Arbitrary](Arbitrary) implementation for `Utf8PathBuf` and `Box<Utf8Path>`.  Note
+//! that implementions for `Rc<Utc8Path>` and `Arc<Utf8Path>` are not currently possible due to
+//! orphan rules - this crate doesn't define `Rc`/`Arc` nor `Arbitrary`, so it can't define those
+//! implementations.
+
+use proptest::arbitrary::{any_with, Arbitrary, StrategyFor};
+use proptest::strategy::{MapInto, Strategy};
+
+use crate::{Utf8Path, Utf8PathBuf};
+
+impl Arbitrary for Utf8PathBuf {
+    type Parameters = <String as Arbitrary>::Parameters;
+    type Strategy = MapInto<StrategyFor<String>, Self>;
+    fn arbitrary_with(args: Self::Parameters) -> Self::Strategy {
+        any_with::<String>(args).prop_map_into()
+    }
+}
+
+impl Arbitrary for Box<Utf8Path> {
+    type Parameters = <Utf8PathBuf as Arbitrary>::Parameters;
+    type Strategy = MapInto<StrategyFor<Utf8PathBuf>, Self>;
+    fn arbitrary_with(args: Self::Parameters) -> Self::Strategy {
+        any_with::<Utf8PathBuf>(args).prop_map_into()
+    }
+}


### PR DESCRIPTION
This makes it easier to proptest code that makes use of `camino`