### PR TITLE
Restrict when `try_reserve_2` is enabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,8 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         # 1.34 is the MSRV, and the other versions add new features through build.rs.
-        rust-version: [ 1.34, 1.44, 1.56, 1.63, stable ]
+        # nightly-2022-06-17 is the last toolchain before `try_reserve_2` was stabilized.
+        rust-version: [ 1.34, 1.44, 1.56, nightly-2022-06-17, 1.63, stable ]
       fail-fast: false
     env:
       RUSTFLAGS: -D warnings

--- a/build.rs
+++ b/build.rs
@@ -24,13 +24,18 @@ fn main() {
     if compiler.minor >= 56 {
         println!("cargo:rustc-cfg=shrink_to");
     }
-    if compiler.minor >= 63 {
+    if compiler.minor >= 63
+        && (!compiler.beta || compiler.minor >= 64)
+        && (!compiler.nightly || compiler.minor >= 65)
+    {
         println!("cargo:rustc-cfg=try_reserve_2");
     }
 }
 
 struct Compiler {
     minor: u32,
+    beta: bool,
+    nightly: bool,
 }
 
 fn rustc_version() -> Option<Compiler> {
@@ -42,5 +47,11 @@ fn rustc_version() -> Option<Compiler> {
         return None;
     }
     let minor = pieces.next()?.parse().ok()?;
-    Some(Compiler { minor })
+    let beta = version.contains("beta");
+    let nightly = version.contains("nightly");
+    Some(Compiler {
+        minor,
+        beta,
+        nightly,
+    })
 }


### PR DESCRIPTION
Ref: https://github.com/camino-rs/camino/pull/21#issuecomment-1212597255

If you decide this PR is too invasive, I won't be insulted if you close it without merging.