### PR TITLE
simplify and fixup check for nightly Rust

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: sunshowers

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,8 @@ on:
       - main
 
 name: Docs
+env:
+  RUSTFLAGS: -D warnings
 
 jobs:
   docs:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1306,6 +1306,8 @@ impl Utf8Path {
     ///
     /// This is a convenience function that coerces errors to false. If you want to
     /// check errors, call [`fs::metadata`].
+    ///
+    /// [`try_exists()`]: Self::try_exists
     #[must_use]
     pub fn exists(&self) -> bool {
         self.0.exists()


### PR DESCRIPTION
The try_reserve_2 feature is enabled on stable and beta Rust 1.63, and
nightly Rust 1.64 and above.