### PR TITLE
Prevent dependabot from opening clap PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,6 @@ updates:
       interval: "daily"
     allow:
       - dependency-type: all
+    ignore:
+      - dependency-name: "clap"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
clap@4 removed support for older Rust versions, this prevents @dependabot from spamming the repo with PRs for an update that won't be accepted.

(Hoping that this is a small quality-of-life improvement for this repository.)