### PR TITLE
Add docstring for Utf8Path::try_from

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -578,7 +578,9 @@ impl Utf8Path {
     /// Returns `None` if the path is not valid UTF-8.
     ///
     /// For a version that returns a type that implements [`std::error::Error`], use the
-    /// `TryFrom<&Path>` impl.
+    /// [`TryFrom<&Path>`][tryfrom] impl.
+    ///
+    /// [tryfrom]: #impl-TryFrom<%26'a+Path>-for-%26'a+Utf8Path
     ///
     /// # Examples
     ///
@@ -2507,6 +2509,31 @@ impl TryFrom<PathBuf> for Utf8PathBuf {
     }
 }
 
+/// Converts a [`Path`] to a [`Utf8Path`].
+///
+/// Returns [`FromPathError`] if the path is not valid UTF-8.
+///
+/// # Examples
+///
+/// ```
+/// use camino::Utf8Path;
+/// use std::convert::TryFrom;
+/// use std::ffi::OsStr;
+/// # #[cfg(unix)]
+/// use std::os::unix::ffi::OsStrExt;
+/// use std::path::Path;
+///
+/// let unicode_path = Path::new("/valid/unicode");
+/// <&Utf8Path>::try_from(unicode_path).expect("valid Unicode path succeeded");
+///
+/// // Paths on Unix can be non-UTF-8.
+/// # #[cfg(unix)]
+/// let non_unicode_str = OsStr::from_bytes(b"\xFF\xFF\xFF");
+/// # #[cfg(unix)]
+/// let non_unicode_path = Path::new(non_unicode_str);
+/// # #[cfg(unix)]
+/// assert!(<&Utf8Path>::try_from(non_unicode_path).is_err(), "non-Unicode path failed");
+/// ```
 impl<'a> TryFrom<&'a Path> for &'a Utf8Path {
     type Error = FromPathError;
 


### PR DESCRIPTION
This docstring is modeled after `Utf8Path::from_path`. The example demonstrates the `<&Utf8Path>::try_from` syntax required to use this method.

Also added a link to the `TryFrom` impl in `Utf8Path::from_path`'s docstring.