### PR TITLE
Draft: Add Redox scheme

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1984,6 +1984,7 @@ pub enum Utf8Prefix<'a> {
     Disk(u8),
 
     /// Redox Scheme
+    #[cfg(target_os = "redox")]
     Scheme(&'a str),
 }
 
@@ -2073,6 +2074,7 @@ impl<'a> Utf8PrefixComponent<'a> {
                 Utf8Prefix::UNC(server, share)
             }
             Prefix::Disk(drive) => Utf8Prefix::Disk(drive),
+            #[cfg(target_os = "redox")]
             Prefix::Scheme(scheme) => Utf8Prefix::Scheme(scheme),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2075,7 +2075,7 @@ impl<'a> Utf8PrefixComponent<'a> {
             }
             Prefix::Disk(drive) => Utf8Prefix::Disk(drive),
             #[cfg(target_os = "redox")]
-            Prefix::Scheme(scheme) => Utf8Prefix::Scheme(scheme),
+            Prefix::Scheme(scheme) => Utf8Prefix::Scheme(unsafe { str_assume_utf8(scheme) }),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1984,7 +1984,6 @@ pub enum Utf8Prefix<'a> {
     Disk(u8),
 
     /// Redox Scheme
-    #[cfg(target_os = "redox")]
     Scheme(&'a str),
 }
 
@@ -2074,7 +2073,6 @@ impl<'a> Utf8PrefixComponent<'a> {
                 Utf8Prefix::UNC(server, share)
             }
             Prefix::Disk(drive) => Utf8Prefix::Disk(drive),
-            #[cfg(target_os = "redox")]
             Prefix::Scheme(scheme) => Utf8Prefix::Scheme(scheme),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1982,6 +1982,10 @@ pub enum Utf8Prefix<'a> {
 
     /// Prefix `C:` for the given disk drive.
     Disk(u8),
+
+    /// Redox Scheme
+    #[cfg(target_os = "redox")]
+    Scheme(&'a str),
 }
 
 impl<'a> Utf8Prefix<'a> {
@@ -2070,6 +2074,8 @@ impl<'a> Utf8PrefixComponent<'a> {
                 Utf8Prefix::UNC(server, share)
             }
             Prefix::Disk(drive) => Utf8Prefix::Disk(drive),
+            #[cfg(target_os = "redox")]
+            Prefix::Scheme(scheme) => Utf8Prefix::Scheme(scheme),
         }
     }
 


### PR DESCRIPTION
Allow Redox Scheme. This is a Path Prefix type that is supported by Redox's fork of `std::path`, but not yet in Rust's main.
[You can see it here.](https://gitlab.redox-os.org/redox-os/rust/-/blob/redox-2023-01-21/library/std/src/path.rs?ref_type=heads#L192)