### PR TITLE
[ci] use M1 runners for macOS builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        # macos-14 for M1 runners
+        os: [ ubuntu-latest, macos-14, windows-latest ]
         # 1.34 is the MSRV, and the other versions add new features through build.rs.
         # The nightly versions are used to ensure that build.rs's version detection is compatible
         # with them:
@@ -54,9 +55,9 @@ jobs:
         exclude:
           # These versions started failing with "archive member 'lib.rmeta' with length 26456 is not
           # mach-o or llvm bitcode file".
-          - os: macos-latest
+          - os: macos-m1
             rust-version: 1.34
-          - os: macos-latest
+          - os: macos-m1
             rust-version: 1.44
       fail-fast: false
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,9 @@ jobs:
         exclude:
           # These versions started failing with "archive member 'lib.rmeta' with length 26456 is not
           # mach-o or llvm bitcode file".
-          - os: macos-m1
+          - os: macos-14
             rust-version: 1.34
-          - os: macos-m1
+          - os: macos-14
             rust-version: 1.44
       fail-fast: false
     env:


### PR DESCRIPTION
https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/