### PR TITLE
chore: Documentation fixes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1402,7 +1402,11 @@ impl Utf8Path {
     ///
     /// ```no_run
     /// use camino::Utf8Path;
-    /// assert!(!Utf8Path::new("does_not_exist.txt").try_exists().expect("Can't check existence of file does_not_exist.txt"));
+    /// assert!(
+    ///     !Utf8Path::new("does_not_exist.txt")
+    ///         .try_exists()
+    ///         .expect("Can't check existence of file does_not_exist.txt")
+    /// );
     /// assert!(Utf8Path::new("/root/secret_file.txt").try_exists().is_err());
     /// ```
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,8 +130,8 @@ impl Utf8PathBuf {
     ///
     /// Errors with the original [`PathBuf`] if it is not valid UTF-8.
     ///
-    /// For a version that returns a type that implements [`std::error::Error`], use the
-    /// [`TryFrom<&PathBuf>`][tryfrom] impl.
+    /// For a version that returns a type that implements [`std::error::Error`],
+    /// see [`TryFrom<&PathBuf>`][tryfrom].
     ///
     /// [tryfrom]: #impl-TryFrom<PathBuf>-for-Utf8PathBuf
     ///
@@ -162,10 +162,12 @@ impl Utf8PathBuf {
         }
     }
 
-    /// Converts a `Utf8PathBuf` to a [`PathBuf`].
+    /// Converts a [`Utf8PathBuf`] to a [`PathBuf`].
     ///
-    /// This is equivalent to the `From<Utf8PathBuf> for PathBuf` impl, but may aid in type
-    /// inference.
+    /// This is equivalent to the [`From<Utf8PathBuf> for PathBuf`][from] implementation,
+    /// but may aid in type inference.
+    ///
+    /// [from]: #impl-From<Utf8PathBuf>-for-PathBuf
     ///
     /// # Examples
     ///
@@ -611,8 +613,8 @@ impl Utf8Path {
     ///
     /// Returns [`None`] if the path is not valid UTF-8.
     ///
-    /// For a version that returns a type that implements [`std::error::Error`], use the
-    /// [`TryFrom<&Path>`][tryfrom] impl.
+    /// For a version that returns a type that implements [`std::error::Error`],
+    /// see [`TryFrom<&Path>`][tryfrom].
     ///
     /// [tryfrom]: #impl-TryFrom<%26Path>-for-%26Utf8Path
     ///
@@ -640,9 +642,12 @@ impl Utf8Path {
         path.as_os_str().to_str().map(Utf8Path::new)
     }
 
-    /// Converts a `Utf8Path` to a [`Path`].
+    /// Converts a [`Utf8Path`] to a [`Path`].
     ///
-    /// This is equivalent to the `AsRef<&Path> for &Utf8Path` impl, but may aid in type inference.
+    /// This is equivalent to the [`AsRef<Path> for Utf8PathBuf`][asref] implementation,
+    /// but may aid in type inference.
+    ///
+    /// [asref]: Utf8PathBuf#impl-AsRef<Path>-for-Utf8PathBuf
     ///
     /// # Examples
     ///
@@ -665,8 +670,8 @@ impl Utf8Path {
 
     /// Yields the underlying [`str`] slice.
     ///
-    /// Unlike [`Path::to_str`], this always returns a slice because the contents of a [`Utf8Path`]
-    /// are guaranteed to be valid UTF-8.
+    /// Unlike [`Path::to_str`], this always returns a slice because the contents
+    /// of a [`Utf8Path`] are guaranteed to be valid UTF-8.
     ///
     /// # Examples
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,12 +6,12 @@
 
 //! UTF-8 encoded paths.
 //!
-//! `camino` is an extension of the `std::path` module that adds new [`Utf8PathBuf`] and [`Utf8Path`]
+//! `camino` is an extension of the [`std::path`] module that adds new [`Utf8PathBuf`] and [`Utf8Path`]
 //! types. These are like the standard library's [`PathBuf`] and [`Path`] types, except they are
 //! guaranteed to only contain UTF-8 encoded data. Therefore, they expose the ability to get their
-//! contents as strings, they implement `Display`, etc.
+//! contents as strings, they implement [`Display`], etc.
 //!
-//! The `std::path` types are not guaranteed to be valid UTF-8. This is the right decision for the standard library,
+//! The [`std::path`] types are not guaranteed to be valid UTF-8. This is the right decision for the standard library,
 //! since it must be as general as possible. However, on all platforms, non-Unicode paths are vanishingly uncommon for a
 //! number of reasons:
 //! * Unicode won. There are still some legacy codebases that store paths in encodings like Shift-JIS, but most
@@ -26,8 +26,8 @@
 //!   cross-platform solution* in systems that support non-UTF-8 paths. However, restricting paths to UTF-8 eliminates
 //!   this problem.
 //!
-//! Therefore, many programs that want to manipulate paths *do* assume they contain UTF-8 data, and convert them to `str`s
-//! as  necessary. However, because this invariant is not encoded in the `Path` type, conversions such as
+//! Therefore, many programs that want to manipulate paths *do* assume they contain UTF-8 data, and convert them to [`str`]s
+//! as  necessary. However, because this invariant is not encoded in the [`Path`] type, conversions such as
 //! `path.to_str().unwrap()` need to be repeated again and again, creating a frustrating experience.
 //!
 //! Instead, `camino` allows you to check that your paths are UTF-8 *once*, and then manipulate them
@@ -65,14 +65,14 @@ mod tests;
 ///
 /// This type provides methods like [`push`] and [`set_extension`] that mutate
 /// the path in place. It also implements [`Deref`] to [`Utf8Path`], meaning that
-/// all methods on [`Utf8Path`] slices are available on `Utf8PathBuf` values as well.
+/// all methods on [`Utf8Path`] slices are available on [`Utf8PathBuf`] values as well.
 ///
 /// [`push`]: Utf8PathBuf::push
 /// [`set_extension`]: Utf8PathBuf::set_extension
 ///
 /// # Examples
 ///
-/// You can use [`push`] to build up a `Utf8PathBuf` from
+/// You can use [`push`] to build up a [`Utf8PathBuf`] from
 /// components:
 ///
 /// ```
@@ -97,7 +97,7 @@ mod tests;
 /// ```
 ///
 /// We can still do better than this! Since these are all strings, we can use
-/// `From::from`:
+/// [`From::from`]:
 ///
 /// ```
 /// use camino::Utf8PathBuf;
@@ -112,7 +112,7 @@ mod tests;
 pub struct Utf8PathBuf(PathBuf);
 
 impl Utf8PathBuf {
-    /// Allocates an empty `Utf8PathBuf`.
+    /// Allocates an empty [`Utf8PathBuf`].
     ///
     /// # Examples
     ///
@@ -126,9 +126,9 @@ impl Utf8PathBuf {
         Utf8PathBuf(PathBuf::new())
     }
 
-    /// Creates a new `Utf8PathBuf` from a `PathBuf` containing valid UTF-8 characters.
+    /// Creates a new [`Utf8PathBuf`] from a [`PathBuf`] containing valid UTF-8 characters.
     ///
-    /// Errors with the original `PathBuf` if it is not valid UTF-8.
+    /// Errors with the original [`PathBuf`] if it is not valid UTF-8.
     ///
     /// For a version that returns a type that implements [`std::error::Error`], use the
     /// `TryFrom<PathBuf>` impl.
@@ -184,7 +184,7 @@ impl Utf8PathBuf {
         self.into()
     }
 
-    /// Creates a new `Utf8PathBuf` with a given capacity used to create the internal [`PathBuf`].
+    /// Creates a new [`Utf8PathBuf`] with a given capacity used to create the internal [`PathBuf`].
     /// See [`with_capacity`] defined on [`PathBuf`].
     ///
     /// *Requires Rust 1.44 or newer.*
@@ -227,14 +227,14 @@ impl Utf8PathBuf {
         unsafe { Utf8Path::assume_utf8(&self.0) }
     }
 
-    /// Consumes and leaks the `Utf8PathBuf`, returning a mutable reference to the contents,
+    /// Consumes and leaks the [`Utf8PathBuf`], returning a mutable reference to the contents,
     /// `&'a mut Utf8Path`.
     ///
     /// The caller has free choice over the returned lifetime, including 'static.
     /// Indeed, this function is ideally used for data that lives for the remainder of
     /// the program’s life, as dropping the returned reference will cause a memory leak.
     ///
-    /// It does not reallocate or shrink the `Utf8PathBuf`, so the leaked allocation may include
+    /// It does not reallocate or shrink the [`Utf8PathBuf`], so the leaked allocation may include
     /// unused capacity that is not part of the returned slice. If you want to discard excess
     /// capacity, call [`into_boxed_path`], and then [`Box::leak`] instead.
     /// However, keep in mind that trimming the capacity may result in a reallocation and copy.
@@ -363,7 +363,7 @@ impl Utf8PathBuf {
         self.0.set_extension(extension.as_ref())
     }
 
-    /// Consumes the `Utf8PathBuf`, yielding its internal [`String`] storage.
+    /// Consumes the [`Utf8PathBuf`], yielding its internal [`String`] storage.
     ///
     /// # Examples
     ///
@@ -379,7 +379,7 @@ impl Utf8PathBuf {
         self.into_os_string().into_string().unwrap()
     }
 
-    /// Consumes the `Utf8PathBuf`, yielding its internal [`OsString`] storage.
+    /// Consumes the [`Utf8PathBuf`], yielding its internal [`OsString`] storage.
     ///
     /// # Examples
     ///
@@ -396,7 +396,7 @@ impl Utf8PathBuf {
         self.0.into_os_string()
     }
 
-    /// Converts this `Utf8PathBuf` into a [boxed](Box) [`Utf8Path`].
+    /// Converts this [`Utf8PathBuf`] into a [boxed](Box) [`Utf8Path`].
     #[must_use = "`self` will be dropped if the result is not used"]
     pub fn into_boxed_path(self) -> Box<Utf8Path> {
         let ptr = Box::into_raw(self.0.into_boxed_path()) as *mut Utf8Path;
@@ -577,7 +577,7 @@ impl<P: AsRef<Utf8Path>> Extend<P> for Utf8PathBuf {
 pub struct Utf8Path(Path);
 
 impl Utf8Path {
-    /// Directly wraps a string slice as a `Utf8Path` slice.
+    /// Directly wraps a string slice as a [`Utf8Path`] slice.
     ///
     /// This is a cost-free conversion.
     ///
@@ -589,7 +589,7 @@ impl Utf8Path {
     /// Utf8Path::new("foo.txt");
     /// ```
     ///
-    /// You can create `Utf8Path`s from `String`s, or even other `Utf8Path`s:
+    /// You can create [`Utf8Path`]s from [`String`]s, or even other [`Utf8Path`]s:
     ///
     /// ```
     /// use camino::Utf8Path;
@@ -605,9 +605,9 @@ impl Utf8Path {
         unsafe { Utf8Path::assume_utf8(path) }
     }
 
-    /// Converts a [`Path`] to a `Utf8Path`.
+    /// Converts a [`Path`] to a [`Utf8Path`].
     ///
-    /// Returns `None` if the path is not valid UTF-8.
+    /// Returns [`None`] if the path is not valid UTF-8.
     ///
     /// For a version that returns a type that implements [`std::error::Error`], use the
     /// [`TryFrom<&Path>`][tryfrom] impl.
@@ -663,7 +663,7 @@ impl Utf8Path {
 
     /// Yields the underlying [`str`] slice.
     ///
-    /// Unlike [`Path::to_str`], this always returns a slice because the contents of a `Utf8Path`
+    /// Unlike [`Path::to_str`], this always returns a slice because the contents of a [`Utf8Path`]
     /// are guaranteed to be valid UTF-8.
     ///
     /// # Examples
@@ -699,7 +699,7 @@ impl Utf8Path {
         self.0.as_os_str()
     }
 
-    /// Converts a `Utf8Path` to an owned [`Utf8PathBuf`].
+    /// Converts a [`Utf8Path`] to an owned [`Utf8PathBuf`].
     ///
     /// # Examples
     ///
@@ -716,14 +716,14 @@ impl Utf8Path {
         Utf8PathBuf(self.0.to_path_buf())
     }
 
-    /// Returns `true` if the `Utf8Path` is absolute, i.e., if it is independent of
+    /// Returns `true` if the [`Utf8Path`] is absolute, i.e., if it is independent of
     /// the current directory.
     ///
     /// * On Unix, a path is absolute if it starts with the root, so
     ///   `is_absolute` and [`has_root`] are equivalent.
     ///
     /// * On Windows, a path is absolute if it has a prefix and starts with the
-    ///   root: `c:\windows` is absolute, while `c:temp` and `\temp` are not.
+    ///   root: `C:\windows` is absolute, while `C:temp` and `\temp` are not.
     ///
     /// # Examples
     ///
@@ -740,7 +740,7 @@ impl Utf8Path {
         self.0.is_absolute()
     }
 
-    /// Returns `true` if the `Utf8Path` is relative, i.e., not absolute.
+    /// Returns `true` if the [`Utf8Path`] is relative, i.e., not absolute.
     ///
     /// See [`is_absolute`]'s documentation for more details.
     ///
@@ -759,13 +759,13 @@ impl Utf8Path {
         self.0.is_relative()
     }
 
-    /// Returns `true` if the `Utf8Path` has a root.
+    /// Returns `true` if the [`Utf8Path`] has a root.
     ///
     /// * On Unix, a path has a root if it begins with `/`.
     ///
     /// * On Windows, a path has a root if it:
     ///     * has no prefix and begins with a separator, e.g., `\windows`
-    ///     * has a prefix followed by a separator, e.g., `c:\windows` but not `c:windows`
+    ///     * has a prefix followed by a separator, e.g., `C:\windows` but not `C:windows`
     ///     * has any non-disk prefix, e.g., `\\server\share`
     ///
     /// # Examples
@@ -781,7 +781,7 @@ impl Utf8Path {
         self.0.has_root()
     }
 
-    /// Returns the `Path` without its final component, if there is one.
+    /// Returns the [`Path`] without its final component, if there is one.
     ///
     /// Returns [`None`] if the path terminates in a root or prefix.
     ///
@@ -807,9 +807,9 @@ impl Utf8Path {
         })
     }
 
-    /// Produces an iterator over `Utf8Path` and its ancestors.
+    /// Produces an iterator over [`Utf8Path`] and its ancestors.
     ///
-    /// The iterator will yield the `Utf8Path` that is returned if the [`parent`] method is used zero
+    /// The iterator will yield the [`Utf8Path`] that is returned if the [`parent`] method is used zero
     /// or more times. That means, the iterator will yield `&self`, `&self.parent().unwrap()`,
     /// `&self.parent().unwrap().parent().unwrap()` and so on. If the [`parent`] method returns
     /// [`None`], the iterator will do likewise. The iterator will always yield at least one value,
@@ -840,7 +840,7 @@ impl Utf8Path {
         Utf8Ancestors(self.0.ancestors())
     }
 
-    /// Returns the final component of the `Utf8Path`, if there is one.
+    /// Returns the final component of the [`Utf8Path`], if there is one.
     ///
     /// If the path is a normal file, this is the file name. If it's the path of a directory, this
     /// is the directory name.
@@ -1229,8 +1229,8 @@ impl Utf8Path {
     /// documentation for more.
     ///
     /// If the resulting path is not UTF-8, an [`io::Error`] is returned with the
-    /// [`ErrorKind`](io::ErrorKind) set to `InvalidData` and the payload set to a
-    /// [`FromPathBufError`].
+    /// [`ErrorKind`](io::ErrorKind) set to [`InvalidData`](io::ErrorKind::InvalidData)
+    /// and the payload set to a [`FromPathBufError`].
     ///
     /// # Examples
     ///
@@ -1277,8 +1277,8 @@ impl Utf8Path {
     /// documentation for more.
     ///
     /// If the resulting path is not UTF-8, an [`io::Error`] is returned with the
-    /// [`ErrorKind`](io::ErrorKind) set to `InvalidData` and the payload set to a
-    /// [`FromPathBufError`].
+    /// [`ErrorKind`](io::ErrorKind) set to [`InvalidData`](io::ErrorKind::InvalidData)
+    /// and the payload set to a [`FromPathBufError`].
     ///
     /// # Examples
     ///
@@ -1328,8 +1328,8 @@ impl Utf8Path {
     /// documentation for more.
     ///
     /// If a directory entry is not UTF-8, an [`io::Error`] is returned with the
-    /// [`ErrorKind`](io::ErrorKind) set to `InvalidData` and the payload set to a
-    /// [`FromPathBufError`].
+    /// [`ErrorKind`](io::ErrorKind) set to [`InvalidData`](io::ErrorKind::InvalidData)
+    /// and the payload set to a [`FromPathBufError`].
     ///
     /// # Examples
     ///
@@ -1384,7 +1384,7 @@ impl Utf8Path {
     /// destination file. In case of broken symbolic links this will return `Ok(false)`.
     ///
     /// As opposed to the [`exists()`] method, this one doesn't silently ignore errors
-    /// unrelated to the path not existing. (E.g. it will return `Err(_)` in case of permission
+    /// unrelated to the path not existing. (E.g. it will return [`Err`] in case of permission
     /// denied on some of the parent directories.)
     ///
     /// Note that while this avoids some pitfalls of the `exists()` method, it still can not
@@ -1509,7 +1509,7 @@ impl Utf8Path {
             .unwrap_or(false)
     }
 
-    /// Converts a `Box<Utf8Path>` into a [`Utf8PathBuf`] without copying or allocating.
+    /// Converts a [`Box<Utf8Path>`] into a [`Utf8PathBuf`] without copying or allocating.
     #[must_use = "`self` will be dropped if the result is not used"]
     #[inline]
     pub fn into_path_buf(self: Box<Utf8Path>) -> Utf8PathBuf {
@@ -1809,7 +1809,7 @@ impl FusedIterator for Iter<'_> {}
 
 /// A single component of a path.
 ///
-/// A `Utf8Component` roughly corresponds to a substring between path separators
+/// A [`Utf8Component`] roughly corresponds to a substring between path separators
 /// (`/` or `\`).
 ///
 /// This `enum` is created by iterating over [`Utf8Components`], which in turn is
@@ -1975,7 +1975,7 @@ impl AsRef<OsStr> for Utf8Component<'_> {
 /// # if cfg!(windows) {
 /// assert_eq!(Verbatim("pictures"), get_path_prefix(r"\\?\pictures\kittens"));
 /// assert_eq!(VerbatimUNC("server", "share"), get_path_prefix(r"\\?\UNC\server\share"));
-/// assert_eq!(VerbatimDisk(b'C'), get_path_prefix(r"\\?\c:\"));
+/// assert_eq!(VerbatimDisk(b'C'), get_path_prefix(r"\\?\C:\"));
 /// assert_eq!(DeviceNS("BrainInterface"), get_path_prefix(r"\\.\BrainInterface"));
 /// assert_eq!(UNC("server", "share"), get_path_prefix(r"\\server\share"));
 /// assert_eq!(Disk(b'C'), get_path_prefix(r"C:\Users\Rust\Pictures\Ferris"));
@@ -2047,7 +2047,7 @@ impl Utf8Prefix<'_> {
 /// representation.
 ///
 /// In addition to the parsed [`Utf8Prefix`] information returned by [`kind`],
-/// `Utf8PrefixComponent` also holds the raw and unparsed [`str`] slice,
+/// [`Utf8PrefixComponent`] also holds the raw and unparsed [`str`] slice,
 /// returned by [`as_str`].
 ///
 /// Instances of this `struct` can be obtained by matching against the
@@ -2062,11 +2062,11 @@ impl Utf8Prefix<'_> {
 /// use camino::{Utf8Component, Utf8Path, Utf8Prefix};
 /// use std::ffi::OsStr;
 ///
-/// let path = Utf8Path::new(r"c:\you\later\");
+/// let path = Utf8Path::new(r"C:\you\later\");
 /// match path.components().next().unwrap() {
 ///     Utf8Component::Prefix(prefix_component) => {
 ///         assert_eq!(Utf8Prefix::Disk(b'C'), prefix_component.kind());
-///         assert_eq!("c:", prefix_component.as_str());
+///         assert_eq!("C:", prefix_component.as_str());
 ///     }
 ///     _ => unreachable!(),
 /// }
@@ -2155,7 +2155,7 @@ impl fmt::Display for Utf8PrefixComponent<'_> {
 /// IO error during iteration.
 ///
 /// If a directory entry is not UTF-8, an [`io::Error`] is returned with the
-/// [`ErrorKind`](io::ErrorKind) set to `InvalidData` and the payload set to a [`FromPathBufError`].
+/// [`ErrorKind`](io::ErrorKind) set to [`InvalidData`][io::ErrorKind::InvalidData] and the payload set to a [`FromPathBufError`].
 #[derive(Debug)]
 pub struct ReadDirUtf8 {
     inner: fs::ReadDir,
@@ -2173,7 +2173,7 @@ impl Iterator for ReadDirUtf8 {
 
 /// Entries returned by the [`ReadDirUtf8`] iterator.
 ///
-/// An instance of `Utf8DirEntry` represents an entry inside of a directory on the filesystem. Each
+/// An instance of [`Utf8DirEntry`] represents an entry inside of a directory on the filesystem. Each
 /// entry can be inspected via methods to learn about the full path or possibly other metadata.
 #[derive(Debug)]
 pub struct Utf8DirEntry {
@@ -2635,7 +2635,7 @@ impl FromPathBufError {
     /// Converts self into a [`std::io::Error`] with kind
     /// [`InvalidData`](io::ErrorKind::InvalidData).
     ///
-    /// Many users of `FromPathBufError` will want to convert it into an `io::Error`. This is a
+    /// Many users of [`FromPathBufError`] will want to convert it into an [`io::Error`]. This is a
     /// convenience method to do that.
     pub fn into_io_error(self) -> io::Error {
         // NOTE: we don't currently implement `From<FromPathBufError> for io::Error` because we want
@@ -2690,7 +2690,7 @@ impl FromPathError {
     /// Converts self into a [`std::io::Error`] with kind
     /// [`InvalidData`](io::ErrorKind::InvalidData).
     ///
-    /// Many users of `FromPathError` will want to convert it into an `io::Error`. This is a
+    /// Many users of [`FromPathError`] will want to convert it into an [`io::Error`]. This is a
     /// convenience method to do that.
     pub fn into_io_error(self) -> io::Error {
         // NOTE: we don't currently implement `From<FromPathBufError> for io::Error` because we want

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,9 @@ impl Utf8PathBuf {
     /// Errors with the original [`PathBuf`] if it is not valid UTF-8.
     ///
     /// For a version that returns a type that implements [`std::error::Error`], use the
-    /// `TryFrom<PathBuf>` impl.
+    /// [`TryFrom<&PathBuf>`][tryfrom] impl.
+    ///
+    /// [tryfrom]: #impl-TryFrom<PathBuf>-for-Utf8PathBuf
     ///
     /// # Examples
     ///
@@ -612,7 +614,7 @@ impl Utf8Path {
     /// For a version that returns a type that implements [`std::error::Error`], use the
     /// [`TryFrom<&Path>`][tryfrom] impl.
     ///
-    /// [tryfrom]: #impl-TryFrom<%26'a+Path>-for-%26'a+Utf8Path
+    /// [tryfrom]: #impl-TryFrom<%26Path>-for-%26Utf8Path
     ///
     /// # Examples
     ///
@@ -2576,7 +2578,9 @@ impl<'a> TryFrom<&'a Path> for &'a Utf8Path {
 
 /// A possible error value while converting a [`PathBuf`] to a [`Utf8PathBuf`].
 ///
-/// Produced by the `TryFrom<PathBuf>` implementation for [`Utf8PathBuf`].
+/// Produced by the [`TryFrom<&PathBuf>`][tryfrom] implementation for [`Utf8PathBuf`].
+///
+/// [tryfrom]: Utf8PathBuf#impl-TryFrom<PathBuf>-for-Utf8PathBuf
 ///
 /// # Examples
 ///
@@ -2658,7 +2662,9 @@ impl error::Error for FromPathBufError {
 
 /// A possible error value while converting a [`Path`] to a [`Utf8Path`].
 ///
-/// Produced by the `TryFrom<&Path>` implementation for [`&Utf8Path`](Utf8Path).
+/// Produced by the [`TryFrom<&Path>`][tryfrom] implementation for [`&Utf8Path`](Utf8Path).
+///
+/// [tryfrom]: Utf8Path#impl-TryFrom<%26Path>-for-%26Utf8Path
 ///
 ///
 /// # Examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2166,7 +2166,8 @@ impl fmt::Display for Utf8PrefixComponent<'_> {
 /// IO error during iteration.
 ///
 /// If a directory entry is not UTF-8, an [`io::Error`] is returned with the
-/// [`ErrorKind`](io::ErrorKind) set to [`InvalidData`][io::ErrorKind::InvalidData] and the payload set to a [`FromPathBufError`].
+/// [`ErrorKind`](io::ErrorKind) set to [`InvalidData`][io::ErrorKind::InvalidData]
+/// and the payload set to a [`FromPathBufError`].
 #[derive(Debug)]
 pub struct ReadDirUtf8 {
     inner: fs::ReadDir,


### PR DESCRIPTION
- Add links and capitalize C: for consistent style
- Fix links, especially links to trait impls.
- Format a couple long lines to be split.