### PR TITLE
add Path and PathBuf methods added in Rust 1.91

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,11 @@
+{
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:github.com)",
+      "WebSearch",
+      "Bash(cargo build:*)",
+      "Bash(cargo test:*)",
+      "Bash(cargo clippy:*)"
+    ]
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
           - 1.74
           - 1.79
           - 1.89
+          - 1.91
           - stable
       fail-fast: false
     env:

--- a/build.rs
+++ b/build.rs
@@ -19,6 +19,8 @@ fn main() {
     println!("cargo:rustc-check-cfg=cfg(os_str_bytes)");
     println!("cargo:rustc-check-cfg=cfg(os_string_pathbuf_leak)");
     println!("cargo:rustc-check-cfg=cfg(absolute_path)");
+    println!("cargo:rustc-check-cfg=cfg(path_add_extension)");
+    println!("cargo:rustc-check-cfg=cfg(pathbuf_const_new)");
 
     let compiler = match rustc_version() {
         Some(compiler) => compiler,
@@ -57,6 +59,16 @@ fn main() {
     if (compiler.minor >= 89 && compiler.channel == ReleaseChannel::Stable) || compiler.minor >= 90
     {
         println!("cargo:rustc-cfg=os_string_pathbuf_leak");
+    }
+    // path_add_extension was added in 1.91.
+    if (compiler.minor >= 91 && compiler.channel == ReleaseChannel::Stable) || compiler.minor >= 92
+    {
+        println!("cargo:rustc-cfg=path_add_extension");
+    }
+    // pathbuf_const_new was added in 1.91.
+    if (compiler.minor >= 91 && compiler.channel == ReleaseChannel::Stable) || compiler.minor >= 92
+    {
+        println!("cargo:rustc-cfg=pathbuf_const_new");
     }
 }
 


### PR DESCRIPTION
Closes #118.