### PR TITLE
perf: delegate `Utf8Path::hash` to the wrapped `Path`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3207,10 +3207,9 @@ impl PartialEq for Utf8Path {
 impl Eq for Utf8Path {}
 
 impl Hash for Utf8Path {
+    #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
-        for component in self.components() {
-            component.hash(state)
-        }
+        self.0.hash(state)
     }
 }
 


### PR DESCRIPTION
## Why

Found while working on rspack-resolver ([rstackjs/rspack-resolver#253](https://github.com/rstackjs/rspack-resolver/pull/253)), which keys hot hash maps on `Utf8Path`.

`impl Hash for Utf8Path` walks `self.components()` and hashes each component separately, paying for the `std::path::Components` iterator state machine on every hash. The wrapped `Path::hash` does the same job in a single-pass byte scan, and is already consistent with `eq`: `Utf8Path::eq` compares `components()`, and `Utf8Components` is a thin wrapper over `std::path::Components`, so equality matches `Path::eq` on the inner path. Delegating to `self.0.hash` is therefore correct and cheaper.

### Before / after

```rust
// before
for component in self.components() {
    component.hash(state)
}
// after
self.0.hash(state)
```

## Benchmark

callgrind on Linux x86_64 (`rustc_hash::FxHasher`), each strategy hashed 400,000×:

| strategy | Ir / hash |
| --- | --- |
| current (`self.components()`) | ~1157 |
| this PR (`self.0.hash`) | ~553 |

**~2.1× fewer instructions.** `std::path::Components::next` alone accounted for ~40% of the benchmark — pure traversal overhead this PR removes.

Benchmark code + full callgrind data: https://gist.github.com/stormslowly/d87d39b9f67ce236fbc144309a606fa1

<details>
<summary>callgrind_annotate output</summary>

```
## inclusive Ir per strategy
691,144,119 (100.0%)  PROGRAM TOTALS
462,950,000 (66.98%)  hash::hash_components   (self.components())
221,250,000 (32.01%)  hash::hash_inner        (self.0.hash)

## top self (exclusive) Ir
277,250,000 (40.11%)  <std::path::Components as Iterator>::next
221,250,000 (32.01%)  hash::hash_inner
180,900,000 (26.17%)  hash::hash_components
```
</details>

## Notes

- `Utf8PathBuf::hash` already forwards to `Utf8Path::hash`, so it benefits too.
- Hash values change (they were never stable API); the `Hash`/`Eq` contract is preserved. `cargo test --all-features` passes, including `test_borrow_hash`.
